### PR TITLE
ssl-handshake: Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.github
+demo/
+Dockerfile
+Makefile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM golang:1.17.5-alpine as builder
+LABEL maintainer "Puru Tuladhar <ptuladhar3@gmail.com>"
+WORKDIR /go/src/github.com/tuladhar/ssl-handshake
+ENV GOPATH=/go
+COPY . .
+RUN go mod download && go install
+
+FROM alpine
+COPY --from=builder /go/bin/ssl-handshake /bin/ssl-handshake
+USER 1001
+ENTRYPOINT ["/bin/ssl-handshake"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+TAG := ssl-handshake:1.5.2
+
+build-image:
+	docker build -t $(TAG) .
+
+push-image: build-image
+	docker tag $(TAG) ptuladhar/$(TAG)
+	docker push ptuladhar/$(TAG)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,21 @@ TLS handshake packets captured with [Wireshark](https://www.wireshark.org/).
 
 ![image](https://user-images.githubusercontent.com/5674762/147404043-7e6d983a-e9c5-4477-a8e2-3e054d4f861d.png)
 
-## Installation
+## Docker Image
+
+Docker image is publicly available at DockerHub:
+* https://hub.docker.com/r/ptuladhar/ssl-handshake
+
+Run `ssl-handshake` as Docker container:
+```
+docker run --rm ptuladhar/ssl-handshake -c 5 tuladhar.github.io:443
+```
+You can also alias `ssl-handshake`, for ease of use:
+```
+alias ssl-handshake="docker run --rm ptuladhar/ssl-handshake"
+ssl-handshake tuladhar.github.com:443
+```
+## Install binary
 Binary is available for Linux, Windows and Mac OS (amd64 and arm64). Download the binary for your respective platform from the [releases page](https://github.com/tuladhar/ssl-handshake/releases).
 
 Linux:


### PR DESCRIPTION
This PR adds Dockerfile for ssl-handshake to be used as a Docker container. The docker image is available at DockerHub: https://hub.docker.com/r/ptuladhar/ssl-handshake

### Usage:
```
docker run --rm ptuladhar/ssl-handshake tuladhar.github.com:443
```