### PR TITLE
New feature: Show TLS Version used during the handshake

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ A command-line tool for testing SSL/TLS handshake latency, written in [Go](https
 ## Features
 * TCP handshake latency
 * SSL/TLS handshake latency
-* Display statistics
+* TLS version used during the handshake
+* Display handshake statistics
 * Configurable endpoint port, handshake interval, timeout and count
 
 ## 


### PR DESCRIPTION
This PR adds support to show TLS version used during the handshake. 

### Supported TLS versions:
- tls1.0, tls1.1, tls1.2, tls1.3

```
[puru@blackhole ssl-handshake]$ ./ssl-handshake -c 3 tuladhar.github.io:443
Starting ssl-handshake v1.5.2 ( https://tuladhar.github.com/ssl-handshake ) at Wed, 29 Dec 2021 15:11:26 +0545
SSL handshake with tuladhar.github.io:443: tcp=286ms handshake=52ms version=tls1.3 total=338ms
SSL handshake with tuladhar.github.io:443: tcp=55ms handshake=58ms version=tls1.3 total=113ms
SSL handshake with tuladhar.github.io:443: tcp=58ms handshake=60ms version=tls1.3 total=118ms

--- tuladhar.github.io:443 handshake statistics ---
3 handshakes sent, finish: 3, fail: 0, time: 2000ms
rtt min/avg/max: 52/56/60 ms
```