### PR TITLE
Add SNI support

### DIFF
--- a/internal/cli.go
+++ b/internal/cli.go
@@ -16,11 +16,13 @@ func (s *SSLHandshake) SetUsage() {
 		fmt.Println()
 		fmt.Println("Options:")
 		fmt.Printf("  -t <timeout>   SSL handshake timeout in milliseconds (default: %d)\n", s.Config.Timeout)
+		fmt.Printf("  -n <name>      Server name indication value (default: unset)\n")
 		fmt.Printf("  -c <count>     Stop after <count> SSL handshakes (default: %d)\n", s.Config.StopCount)
 		fmt.Printf("  -i <interval>  Wait <interval> milliseconds between SSL handshakes (default: %d)\n", s.Config.Interval)
 		fmt.Println()
 		fmt.Println("Examples:")
 		fmt.Printf("  %s tuladhar.github.com:443\n", s.Metadata.Name)
+		fmt.Printf("  %s -n dns.google 8.8.8.8:443\n", s.Metadata.Name)
 		fmt.Printf("  %s -c 3 -i 500 tuladhar.github.com:443\n", s.Metadata.Name)
 		fmt.Printf("  %s -t 500 imap.gmail.com:993\n", s.Metadata.Name)
 	}
@@ -30,6 +32,7 @@ func (s *SSLHandshake) ParseFlag() {
 	flag.Int64Var(&s.Config.Timeout, "t", s.Config.Timeout, "")
 	flag.Int64Var(&s.Config.StopCount, "c", s.Config.StopCount, "")
 	flag.Int64Var(&s.Config.Interval, "i", s.Config.Interval, "")
+	flag.StringVar(&s.Config.ServerName, "n", "", "")
 
 	flag.Parse()
 	if len(flag.Args()) != 1 {

--- a/internal/sslhandshake.go
+++ b/internal/sslhandshake.go
@@ -16,10 +16,11 @@ type SSLHandshakeMetadata struct {
 }
 
 type SSLHandshakeConfig struct {
-	Endpoint  string
-	Interval  int64
-	Timeout   int64
-	StopCount int64
+	Endpoint   string
+	Interval   int64
+	ServerName string
+	StopCount  int64
+	Timeout    int64
 }
 
 type SSLHandshakeState struct {
@@ -52,6 +53,9 @@ func (s *SSLHandshake) EstablishTcp() (*net.Conn, int64, error) {
 func (s *SSLHandshake) DoHandshake() (int64, uint16, int64, error) {
 	tlsConfig := tls.Config{
 		InsecureSkipVerify: true,
+	}
+	if s.Config.ServerName != "" {
+		tlsConfig.ServerName = s.Config.ServerName
 	}
 
 	tcpConn, tcpTime, tcpErr := s.EstablishTcp()

--- a/main.go
+++ b/main.go
@@ -13,10 +13,11 @@ func main() {
 			URL:         "https://github.com/tuladhar/ssl-handshake",
 		},
 		Config: &sslhandshake.SSLHandshakeConfig{
-			Endpoint:  "",
-			Interval:  1000,
-			Timeout:   5000,
-			StopCount: 0,
+			Endpoint:   "",
+			Interval:   1000,
+			ServerName: "",
+			StopCount:  0,
+			Timeout:    5000,
 		},
 		State: &sslhandshake.SSLHandshakeState{},
 	}


### PR DESCRIPTION
Many websites require a [server name indication](https://en.wikipedia.org/wiki/Server_Name_Indication) during the SSL handshake (to decide what certificate to present to the client, or to even allow the request) or route the request (common method in the case of L4 load-balancing notably).

This PR adds support for this.

Note: In principle, one can use the host portion of the endpoint as a default for it when it's a hostname (which would mimick the default behaviour of most HTTP client implementations), but that'd technically be a breaking change so I refrained.